### PR TITLE
Delete custom style for mobile usability

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -89,47 +89,6 @@ textarea {
 
 /* Layout */
 
-body {
-  display: grid;
-  grid-column-gap: 2em;
-  grid-auto-columns: minmax(0, 1.5fr) minmax(0, 3fr) minmax(0, 2fr);
-  grid-auto-rows: calc(100vh - 2em) auto;
-  grid-auto-flow: column;
-  border-top: 2em solid #8a2a2f;
-  min-height: 100vh;
-  box-sizing: border-box;
-}
-#book {
-  grid-column-start: 1;
-  grid-column-end: 2;
-  grid-row-start: 1;
-  grid-row-end: 4;
-  padding: 2em 3em;
-}
-#testimonials {
-  grid-column-start: 3;
-  grid-column-end: 4;
-  grid-row-start: 1;
-  grid-row-end: 4;
-  padding: 2em 0;
-  padding-right: 2em;
-}
-#features {
-  grid-column-start: 2;
-  grid-column-end: 3;
-  grid-row-start: 1;
-  grid-row-end: 2;
-  padding-top: 2em;
-}
-#errata {
-  grid-column-start: 2;
-  grid-column-end: 3;
-  grid-row-start: 2;
-  grid-row-end: 3;
-  padding-top: 2em;
-  padding-right: 2em;
-}
-
 /* General styles */
 
 h2 {


### PR DESCRIPTION
Hi, really appreciate your great YouTube channel. Wish there was an issue tab but there was not so I report a bug here. The website looks great on desktop but it looks kinda borderline unreadable in mobile devices.  Removing the custom css doesn't look great but at least helps a little in usability.

Below is a screenshot after the change.

<img width="420" alt="image" src="https://user-images.githubusercontent.com/70570804/147060799-fc35823e-53f5-4549-be77-c2963cf6a82f.png">

Just wanted to report this issue and don't mind you closing it. Really love the channel, bye.