### PR TITLE
Fix long border in Desktop view

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -364,7 +364,7 @@ pre {
     grid-row-gap: 1em;
     grid-auto-columns: 20em minmax(0, 1fr);
     grid-auto-flow: column;
-    border-bottom: 100vh #fffcc5 solid;
+    border-bottom: 20px #fffcc5 solid;
   }
   section {
     padding: 0;


### PR DESCRIPTION
<img width="1438" alt="Screen Shot 2021-12-23 at 10 56 58 PM" src="https://user-images.githubusercontent.com/40111357/147314381-4e5d76a7-b185-4784-a90c-5564060ec6f9.png">

Not sure if this was intended, but I see an extended border at the bottom of the page. This PR changes the size from `100vh` to `20px`.