### PR TITLE
iBooks code formatting is incorrect

### DIFF
--- a/_errata/print01-ch01-listing7-formating.md
+++ b/_errata/print01-ch01-listing7-formating.md
@@ -1,0 +1,18 @@
+---
+chapter: 1
+page: 24
+kind: code
+reporter: iwahbe
+date: 2021-12-24
+---
+The code formatting on iBooks is always wrong. I see correct highlighting  distinction
+between comment and code, but neither indentation or lines are correct. 
+
+This is the listing 1-7 as I see it (indentation and line breaks) on iBooks:
+```rust
+fn replace_with_84(s: &mut Box<i32>) { // this is not okay, as *s would be empty: {1}
+// let was = *s; // but this is:{2} let was = std::mem::take(s); // so is this: {3} *s =
+was; // we can exchange values behind &mut: let mut r = Box::new(84);{4}
+```
+
+I am replacing the numbered tags with `{n}`. 


### PR DESCRIPTION
I'm not sure if this is the correct place for this type of feedback. Please let me know if I should submit this somewhere else. I have included a screenshot of how code snippets render in iBooks. It seems like indentation and line breaks are ignored. 
![IMG_0035](https://user-images.githubusercontent.com/22222529/147381428-74151147-7d0c-4d1f-84ad-e3804b26173c.jpeg)
 