### PR TITLE
Erreta print01-ch09-lst01-mut

### DIFF
--- a/_errata/print01-ch09-lst01-mut.md
+++ b/_errata/print01-ch09-lst01-mut.md
@@ -1,0 +1,27 @@
+---
+chapter: 9
+page: 142
+kind: code
+reporter: Callum Iddon
+date: 2022-01-07
+# fixed: 2021-01-01
+---
+Listing 9-1 says
+
+```rust
+impl<T> SomeType<T> {
+    pub unsafe fn decr(&self) {
+        self.some_usize -= 1;
+    }
+}
+```
+
+but should say
+
+```rust
+impl<T> SomeType<T> {
+    pub unsafe fn decr(&mut self) {
+        self.some_usize -= 1;
+    }
+}
+```


### PR DESCRIPTION
*Apologies for the duplicated PR as this is identical to #9, I deleted my fork not knowing it would automatically close the PR and it cannot be reopened as forks cannot be restored.*

The subtraction assignment operator is used on `self.some_usize` inside the `decr` method which only has a shared reference to `self`. This does not compile as the [`SubAssign`](https://doc.rust-lang.org/std/ops/trait.SubAssign.html) trait requires a mutable reference to `self`.

[Rust Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=cd9a1e2b2eb4a3ff7949f34db045a637)