### PR TITLE
Erreta print01-ch09-lst10-type

### DIFF
--- a/_errata/print01-ch09-lst10-type.md
+++ b/_errata/print01-ch09-lst10-type.md
@@ -1,0 +1,25 @@
+---
+chapter: 9
+page: 161
+kind: code
+reporter: Callum Iddon
+date: 2022-01-11
+# fixed: 2021-01-01
+---
+Listing 9-10 says
+
+```rust
+fn barify<’a>(_: &’a mut i32) -> Bar<Foo<’a>> { .. }
+let mut x = true;
+let foo = barify(&mut x);
+x = false;
+```
+
+but should say
+
+```rust
+fn barify<'a>(_: &'a mut bool) -> Bar<Foo<'a>> { .. }
+let mut x = true;
+let foo = barify(&mut x);
+x = false;
+```


### PR DESCRIPTION
The `barify` function takes a `&mut i32` and is passed a `&mut bool`. Also, the lifetimes are declared using a right single quotation mark (`\u{2019}`) instead of an apostrophe (`\u{27}`).