### PR TITLE
errata print01-ch07-lst1 mismatched opening and closing parans

### DIFF
--- a/_errata/print01-ch07-lst1-matcher.md
+++ b/_errata/print01-ch07-lst1-matcher.md
@@ -1,0 +1,27 @@
+---
+chapter: 7
+page: 103
+kind: code
+reporter: AJ ONeal
+date: 2022-01-09
+---
+
+Listing 7-1 has three closing parens
+
+```rust
+macro_rules! test_battery {
+  ($($t:ty as $name:ident),*)) => {
+    // ...
+  }
+}
+```
+
+but should have only two
+
+```rust
+macro_rules! test_battery {
+  ($($t:ty as $name:ident),*) => {
+    // ...
+  }
+}
+```


### PR DESCRIPTION
Had 2 opening parens, but 3 closing parens.

```diff
macro_rules! test_battery {
-  ($($t:ty as $name:ident),*)) => {
+  ($($t:ty as $name:ident),*) => {
    // ...
  }
}
```


This was actually quite confusing as its the code sample for macros and since I didn't understand the syntax at all, I thought the extra `)` was some sort of special match syntax or directive.

(I'm very rust-beginner - below the target audience for this book, for sure)