### PR TITLE
Add errata print01-ch08-lst14-some-to-ok

### DIFF
--- a/_errata/print01-ch08-lst14-some-to-ok.md
+++ b/_errata/print01-ch08-lst14-some-to-ok.md
@@ -14,7 +14,7 @@ async fn handle_client(socket: TcpStream) -> Result<()> {
 }
 
 async fn server(socket: TcpListener) -> Result<()> {
-    while let Some() = socket.accept().await? {
+    while let Some(stream) = socket.accept().await? {
         handle_client(stream).await?;
     }
 }

--- a/_errata/print01-ch08-lst14-some-to-ok.md
+++ b/_errata/print01-ch08-lst14-some-to-ok.md
@@ -1,0 +1,35 @@
+---
+chapter: 8
+kind: code
+reporter: SARDONYX
+page: 138
+date: 2023-06-25
+---
+
+Listing 8-14 says
+
+```rust
+async fn handle_client(socket: TcpStream) -> Result<()> {
+    // Interact with the client over the given socket.
+}
+
+async fn server(socket: TcpListener) -> Result<()> {
+    while let Some() = socket.accept().await? {
+        handle_client(stream).await?;
+    }
+}
+```
+
+but should say
+
+```rust
+async fn handle_client(socket: TcpStream) -> Result<()> {
+    // Interact with the client over the given socket.
+}
+
+async fn server(socket: TcpListener) -> Result<()> {
+    while let Ok(stream) = socket.accept().await? {
+        handle_client(stream).await?;
+    }
+}
+```


### PR DESCRIPTION
- Return value is `Result<()>` I think we need to use `Ok(T)` because I use `Some(T)` in `?` operator and destructuring assignment.

- If this PR is correct, then the example where the accept method is called in the same way could also be errata. (e.g. Listing 8-15, 8-16).