### PR TITLE
Errata print01-ch08-of

### DIFF
--- a/_errata/print01-ch08-of.md
+++ b/_errata/print01-ch08-of.md
@@ -1,0 +1,15 @@
+---
+chapter: 8
+page: 133
+kind: typo
+reporter: Joel Posti
+date: 2023-10-29
+---
+
+The second to last sentence of the first paragraph says
+
+> so no code is able to move out of the value in `pinned`
+
+but it should say
+
+> so no code is able to move out the value in `pinned`


### PR DESCRIPTION
This pull request contains a minor typo fix for chapter 8 page 133. I am fairly sure that the ‘of’ word should not be in the sentence, because certainly code cannot move out of a value.

I have another comment regarding the same sentence. The following is not yet reflected in the commits of this pull request as I am unsure, if I simply have misunderstood something. The full sentence is like so with the second issue highlighted with bolding:

> Furthermore, `pinned` is not accessible except through a `Pin` **once we're in the loop**, so no code is able to move out of the value in `pinned`.

I am not certain which loop the sentence refers to (a number ball would help here), but if it refers to the loop on the 2nd line of listing 8-12, isn't `pinned` directly accessible just fine inside the loop? I mean, theoretically you could do something like this, if you could persuade the compiler to produce such code:

```rs
use std::pin::Pin;

fn main() {
    match "foo" {
        mut pinned => loop {
            println!("I can access pinned: {pinned}");

            match unsafe { Pin::new_unchecked(&mut pinned) } {
                pinned_pinned => { println!("pinned_pinned: {pinned_pinned}"); }
            }

            println!("I can access pinned after pinning: {pinned}");
        }
    }
}
```

I thank you very much in advance for your time and patience.