### PR TITLE
Errata: reference immutability does not apply through pointers

### DIFF
--- a/_errata/print01-ch09-mut-ptr-through-shared.md
+++ b/_errata/print01-ch09-mut-ptr-through-shared.md
@@ -1,0 +1,17 @@
+---
+chapter: 9
+page: 156
+kind: inaccuracy
+reporter: ijchen
+date: 2025-10-06
+# fixed: 2021-01-01
+---
+The following is inaccurate:
+
+> ...so if you have an `&` to a type that contains a `*mut T`, you are not allowed to ever mutate
+> the `T` through that `*mut` even though you could write code to do so using `unsafe`.
+
+While it's true that you cannot mutate data *within* the `T` of a `&T` (including transitively),
+this immutability does not travel through pointers. You cannot mutate the pointer itself (i.e., it
+would not be okay to mutate the pointer's address), but this immutability does not prevent mutating
+*through* pointers stored behind the reference.


### PR DESCRIPTION
See: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=e4bf9820cfaff780037a7c135d9b0f0a

(I'm a huge fan - thanks for all your incredible educational Rust content! :heart::crab:)