### PR TITLE
Fix CI failure by updating deprecated GitHub Actions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Ruby
         uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
         with:
@@ -41,7 +41,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -49,7 +49,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
 
   # Deployment job
   deploy:
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
CI seems broken: https://github.com/jonhoo/rust-for-rustaceans.com/actions/runs/18290144298

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.

Looking at the error, I think we just need to update `upload-pages-artifact` from v2 -> v3 or later ([changelog for v3](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0), which includes bumping `upload-artifact` to v4)

I went ahead and updated the other actions to their latest versions as well. I didn't see any incompatibilities looking through the changelogs, but I'm also not really a CI guy. For convenience, here are links to changelogs for each action updated:
- [`actions/checkout`](https://github.com/actions/checkout/releases) (v4 -> v5)
- [`actions/configure-pages`](https://github.com/actions/configure-pages/releases) (v4 -> v5)
- [`actions/upload-pages-artifact`](https://github.com/actions/upload-pages-artifact/releases) (v2 -> v4)
- [`actions/deploy-pages`](https://github.com/actions/deploy-pages/releases) (v3 -> v4)